### PR TITLE
账号大小写导致查看群信息时无法区分管理员

### DIFF
--- a/demo/src/components/group/GroupInfo.js
+++ b/demo/src/components/group/GroupInfo.js
@@ -136,7 +136,7 @@ class GroupInfo extends React.Component {
 
     renderGroupOperationMenu = () => {
         const { login, groupMember, room } = this.props
-        const user = _.get(groupMember, [ room.groupId, "byName", _.get(login, "username") ], {
+        const user = _.get(groupMember, [ room.groupId, "byName", _.get(login, "username").toLowerCase() ], {
             name: null,
             affiliation: null
         })

--- a/demo/src/components/group/GroupMembers.js
+++ b/demo/src/components/group/GroupMembers.js
@@ -50,9 +50,9 @@ class GroupMembers extends React.Component {
 
         const data = _.map(members, (val, key) => {
             const { affiliation } = val
-            if (affiliation === "owner") {
-                owner = key
-                if (key === currentUser) {
+            if (affiliation.toLowerCase() === "owner") {
+                owner = key.toLowerCase()
+                if (key === currentUser.toLowerCase()) {
                     isOwner = true
                 }
             }


### PR DESCRIPTION
账号大小写导致查看群信息时无法区分管理员