### PR TITLE
1.demo 依赖了easemob-webrtc 和 easemob-emedia的发布版本（因为是一个完整的js，两个库中都有webrt…

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -37,7 +37,6 @@
     "deepcopy": "^0.6.3",
     "dexie": "^2.0.0-rc.1",
     "dotenv": "4.0.0",
-    "easemob-emedia": "^2.1.2",
     "easemob-webrtc": "^3.0.7",
     "easemob-websdk": "^3.0.6",
     "eruda": "^1.2.5",

--- a/demo/src/config/WebIM.js
+++ b/demo/src/config/WebIM.js
@@ -3,7 +3,6 @@
 /* eslint-enable */
 import websdk from 'easemob-websdk'
 import webrtc from 'easemob-webrtc'
-import emedia from 'easemob-emedia'
 import config from 'WebIMConfig'
 import emoji from './emoji'
 import Api from 'axios'
@@ -36,7 +35,7 @@ WebIM.conn = new websdk.connection({
     appKey: WebIM.config.appkey
 })
 
-// for downward compatibility 
+// for downward compatibility
 if (!WebIM.conn.apiUrl) {
     WebIM.conn.apiUrl = WebIM.config.apiURL
 }
@@ -79,8 +78,12 @@ api.interceptors.response.use(
     }
 )
 
+emedia.config({
+    forceUseVideoCodecs:["VP8", "H264"]
+});
+
 WebIM.api = api
 WebIM.emoji = emoji
 WebIM.WebRTC = webrtc
-WebIM.EMedia = emedia
+WebIM.EMedia = emedia || webrtc.emedia
 export default WebIM


### PR DESCRIPTION
…c-adapter），这时候就会出现问题。webrtc-adapter被import了两次。safari 产生的sdp 包含了多个video audio段，xswitch无法处理，从而失败。

2.手机sdk 3.6.2 不支持H264编码；safari较新版本已经开始支持了VP8；为了让各端能够互通，强制设置编码优先级forceUseVideoCodecs:["VP8", "H264"]